### PR TITLE
Mark errors as unused

### DIFF
--- a/lib/mix/gen_schema.ex
+++ b/lib/mix/gen_schema.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Pow.Postgres.Gen.Schema do
   end
 
   def run(args) do
-    {options, [filename], errors} = OptionParser.parse(args, strict: @flags)
+    {options, [filename], _errors} = OptionParser.parse(args, strict: @flags)
     assigns =
       Keyword.merge(@defaults, options)
       |> Keyword.take([:datetime_type, :schema_name, :schema_module_name, :module_prefix])


### PR DESCRIPTION
Elixir was warning that `errors` is unused.  This small fix just renames it to silence the warning.